### PR TITLE
Bug sd163 early navbar collapse

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -1,0 +1,71 @@
+
+
+## Dev setup
+
+The [project documentation](http://dai-softsource.uni-koeln.de/projects/thesaurus/wiki) advises to use __ruby 2.3.1__ as in production.
+
+As that version is no longer available in recent (19.04+, due to a missing libssl01-dev) ubuntu, I used __ruby 2.6.3__. The basic setup seems to work with that version as well.
+
+
+1. create `config/database.yml` with:
+
+```
+development:
+  adapter: postgresql
+  encoding: unicode
+  database: iqvoc_skosxl_development
+  pool: 5
+  username: iqvoc
+  password: iqvoc
+```
+
+You might have to adjust the 'pg'-line in the Gemfile setting version 0.15:
+
+```ruby
+platforms :ruby do
+  gem 'pg', '~> 0.15'
+end
+```
+
+2. Create the database user:
+
+```bash
+sudo -u postgres psql
+```
+
+And in the postgres shell:
+
+```sql
+CREATE user iqvoc WITH PASSWORD 'iqvoc';
+CREATE DATABASE iqvoc_skosxl_development;
+GRANT ALL PRIVILEGES ON DATABASE iqvoc_skosxl_development TO iqvoc;
+```
+
+Allow local access with passwords by changing in `/etc/postgresql/11/main/pg_hba.conf` the line:
+
+```
+local all all peer
+```
+
+to
+
+```
+local all all md5
+```
+
+You might need to restart postgres, e.g. with `sudo service postgresql restart`
+
+3. Run migrations
+
+```
+rake db:migrate
+rake iqvoc:db:seed_all
+```
+
+4. Start dev server
+
+```
+rails s
+```
+
+The application is available on localhost:3000

--- a/app/assets/stylesheets/iqvoc_skosxl/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/iqvoc_skosxl/_bootstrap_overrides.scss
@@ -1,0 +1,9 @@
+/**
+ * Place to override variables from the iqvoc bootstrap variables.
+ *
+ * see: https://github.com/innoq/iqvoc/blob/master/app/assets/stylesheets/iqvoc/settings/_bootstrap-variables.scss
+ */
+
+//** These are viewport widths at which the navbar (un-)collapses
+$grid-float-breakpoint: 632px;
+$grid-float-breakpoint-max: ($grid-float-breakpoint - 1);

--- a/app/assets/stylesheets/manifest.css.scss
+++ b/app/assets/stylesheets/manifest.css.scss
@@ -1,4 +1,6 @@
+
 @import 'iqvoc/settings/bootstrap-variables';
+@import 'iqvoc_skosxl/bootstrap_overrides';
 @import 'framework';
 @import 'iqvoc/manifest';
 @import 'iqvoc_skosxl/manifest';

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -1,10 +1,7 @@
 <nav class="navbar navbar-default navbar-fixed-top">
   <div class="container">
     <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-        <span class="sr-only">Toggle navigation</span>
-        <i class="fa fa-bars"></i> <%= t('txt.common.menu') %>
-      </button>
+
 
       <ul class="nav navbar-nav">
         <li class="dropdown">
@@ -19,6 +16,11 @@
       </ul>
 
       <%= link_to Iqvoc.config["title"], localized_root_path, class: 'navbar-brand' %>
+
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+        <span class="sr-only">Toggle navigation</span>
+        <i class="fa fa-bars"></i> <%= t('txt.common.menu') %>
+      </button>
     </div>
 
     <div id="navbar" class="navbar-collapse collapse">


### PR DESCRIPTION
This fixes two issues:
* the navbar collapses at 1200px viewport width, which is too early
* once the navbar is collapsed, the griffin icon overlay the menu making it unusable